### PR TITLE
Fix the hook for taking items to allow for renaming stacks

### DIFF
--- a/src/main/java/svenhjol/charm/charmony/common/mixin/event/anvil_update/AnvilMenuMixin.java
+++ b/src/main/java/svenhjol/charm/charmony/common/mixin/event/anvil_update/AnvilMenuMixin.java
@@ -67,6 +67,8 @@ public abstract class AnvilMenuMixin extends ItemCombinerMenu {
             } else {
                 inputSlots.setItem(slot, stack);
             }
+        } else {
+            inputSlots.setItem(slot, stack);
         }
     }
 }

--- a/src/main/java/svenhjol/charm/charmony/common/mixin/event/anvil_update/AnvilMenuMixin.java
+++ b/src/main/java/svenhjol/charm/charmony/common/mixin/event/anvil_update/AnvilMenuMixin.java
@@ -61,8 +61,12 @@ public abstract class AnvilMenuMixin extends ItemCombinerMenu {
     private void hookOnTakeSetItem(Container inputSlots, int slot, ItemStack stack) {
         if (Resolve.feature(Core.class).customOnTakeBehavior() && stack == ItemStack.EMPTY) {
             var original = inputSlots.getItem(slot);
-            original.shrink(1);
-            inputSlots.setItem(slot, original);
+            if (original.isEnchanted()) {
+                original.shrink(1);
+                inputSlots.setItem(slot, original);
+            } else {
+                inputSlots.setItem(slot, stack);
+            }
         }
     }
 }


### PR DESCRIPTION
There's currently a bug where the custom on-take behavior for anvils disallows naming stacks of items. This just modifies the code so that it only applies if the items are enchanted, rather than unenchanted items like nametags.